### PR TITLE
✨Feat: 검색 결과 페이지 UI  구현

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -227,3 +227,12 @@ input[type='date']::placeholder {
 .bg-gradient-main {
   background: linear-gradient(to bottom, #bbddff, #f7fbff, #ffffff);
 }
+
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
+.no-scrollbar {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,10 +14,13 @@ export default function RootLayout({
   const pathname = usePathname();
   const hideLayout = pathname === '/login' || pathname === '/signup';
   const isHome = pathname === '/';
+  const isSearch = pathname.startsWith('/search');
 
   return (
     <html lang='ko'>
-      <body className={clsx('min-h-screen flex flex-col', isHome && 'bg-gradient-main')}>
+      <body
+        className={clsx('min-h-screen flex flex-col', (isHome || isSearch) && 'bg-gradient-main')}
+      >
         {!hideLayout && <Header />}
         <main className='flex-1'>{children}</main>
         {!hideLayout && <Footer />}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -4,6 +4,7 @@
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import axios from '@/lib/api/axios';
+import type { Activity } from '@/components/landing/LandingCard';
 import LandingCard from '@/components/landing/LandingCard';
 import Pagination from '@/components/common/Pagination';
 import NoResult from '@/components/search/NoResult';
@@ -15,7 +16,7 @@ const SearchPage = () => {
   const size = 8;
   const router = useRouter();
 
-  const [activities, setActivities] = useState([]);
+  const [activities, setActivities] = useState<Activity[]>([]);
   const [totalCount, setTotalCount] = useState(0);
 
   useEffect(() => {

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,4 +1,3 @@
-// app/search/page.tsx
 'use client';
 
 import { useRouter, useSearchParams } from 'next/navigation';
@@ -8,6 +7,8 @@ import type { Activity } from '@/components/landing/LandingCard';
 import LandingCard from '@/components/landing/LandingCard';
 import Pagination from '@/components/common/Pagination';
 import NoResult from '@/components/search/NoResult';
+import Banner from '@/components/landing/Banner';
+import SearchBar from '@/components/landing/SearchBar';
 
 const SearchPage = () => {
   const searchParams = useSearchParams();
@@ -45,31 +46,41 @@ const SearchPage = () => {
 
   return (
     <main className='w-full min-h-screen px-20'>
-      <div className='text-20-b mb-20'>{`‘${keyword}’에 대한 검색 결과입니다.`}</div>
+      <div className='max-w-screen-xl mx-auto'>
+        {/* 배너 & 검색바 */}
+        <Banner />
+        <SearchBar />
 
-      {activities.length === 0 ? (
-        <NoResult />
-      ) : (
-        <>
-          <section className='grid grid-cols-2 md:grid-cols-2 lg:grid-cols-4 gap-20'>
-            {activities.map((activity) => (
-              <LandingCard key={activity.id} activity={activity} />
-            ))}
-          </section>
-          {totalCount > 0 && (
-            <Pagination
-              currentPage={page}
-              totalPages={totalPages}
-              onPageChange={(newPage) => {
-                const newParams = new URLSearchParams(searchParams.toString());
-                newParams.set('page', newPage.toString());
-                router.push(`?${newParams.toString()}`);
-                window.scrollTo({ top: 0, behavior: 'smooth' });
-              }}
-            />
-          )}
-        </>
-      )}
+        {/* 검색 결과 안내 텍스트 */}
+        <div className='text-20-b mt-40 mb-10'>‘{keyword}’에 대한 검색 결과입니다.</div>
+        {totalCount > 0 && <div className='text-14-m text-gray-400'>총 {totalCount}개의 결과</div>}
+        {/* 결과 리스트 */}
+        {activities.length === 0 ? (
+          <NoResult />
+        ) : (
+          <>
+            <section className='grid grid-cols-2 md:grid-cols-2 lg:grid-cols-4 gap-20'>
+              {activities.map((activity) => (
+                <LandingCard key={activity.id} activity={activity} />
+              ))}
+            </section>
+
+            {/* 페이지네이션 */}
+            {totalCount > 0 && (
+              <Pagination
+                currentPage={page}
+                totalPages={totalPages}
+                onPageChange={(newPage) => {
+                  const newParams = new URLSearchParams(searchParams.toString());
+                  newParams.set('page', newPage.toString());
+                  router.push(`?${newParams.toString()}`);
+                  window.scrollTo({ top: 0, behavior: 'smooth' });
+                }}
+              />
+            )}
+          </>
+        )}
+      </div>
     </main>
   );
 };

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,76 @@
+// app/search/page.tsx
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import axios from '@/lib/api/axios';
+import LandingCard from '@/components/landing/LandingCard';
+import Pagination from '@/components/common/Pagination';
+import NoResult from '@/components/search/NoResult';
+
+const SearchPage = () => {
+  const searchParams = useSearchParams();
+  const keyword = searchParams.get('keyword') || '';
+  const page = Number(searchParams.get('page')) || 1;
+  const size = 8;
+  const router = useRouter();
+
+  const [activities, setActivities] = useState([]);
+  const [totalCount, setTotalCount] = useState(0);
+
+  useEffect(() => {
+    const fetchActivities = async () => {
+      try {
+        const res = await axios.get(`/activities`, {
+          params: {
+            method: 'offset',
+            keyword,
+            page,
+            size,
+          },
+        });
+
+        setActivities(res.data.activities);
+        setTotalCount(res.data.totalCount);
+      } catch (err) {
+        console.error('검색 결과 요청 실패', err);
+      }
+    };
+
+    fetchActivities();
+  }, [keyword, page]);
+
+  const totalPages = Math.ceil(totalCount / size);
+
+  return (
+    <main className='w-full min-h-screen px-20'>
+      <div className='text-20-b mb-20'>{`‘${keyword}’에 대한 검색 결과입니다.`}</div>
+
+      {activities.length === 0 ? (
+        <NoResult />
+      ) : (
+        <>
+          <section className='grid grid-cols-2 md:grid-cols-2 lg:grid-cols-4 gap-20'>
+            {activities.map((activity) => (
+              <LandingCard key={activity.id} activity={activity} />
+            ))}
+          </section>
+          {totalCount > 0 && (
+            <Pagination
+              currentPage={page}
+              totalPages={totalPages}
+              onPageChange={(newPage) => {
+                const newParams = new URLSearchParams(searchParams.toString());
+                newParams.set('page', newPage.toString());
+                router.push(`?${newParams.toString()}`);
+                window.scrollTo({ top: 0, behavior: 'smooth' });
+              }}
+            />
+          )}
+        </>
+      )}
+    </main>
+  );
+};
+
+export default SearchPage;

--- a/src/components/landing/AllActivities.tsx
+++ b/src/components/landing/AllActivities.tsx
@@ -95,7 +95,7 @@ const AllActivities = () => {
       {/* 카드 목록 */}
       <div className='grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-4 gap-16 sm:gap-24 no-scrollbar'>
         {mockActivities.map((item) => (
-          <LandingCard key={item.id} {...item} />
+          <LandingCard key={item.id} activity={item} />
         ))}
       </div>
       {/* 페이지네이션 */}

--- a/src/components/landing/CategoryFilter.tsx
+++ b/src/components/landing/CategoryFilter.tsx
@@ -19,7 +19,7 @@ const CATEGORY_LIST = [
 
 const CategoryFilter = ({ selectedCategory, onSelectCategory }: CategoryFilterProps) => {
   return (
-    <div className='flex overflow-x-auto no-scrollbar sm:flex-wrap gap-8'>
+    <div className='flex overflow-x-auto no-scrollbar sm:flex-wrap gap-8 cursor-pointer'>
       {CATEGORY_LIST.map(({ label, icon }) => {
         const isSelected = selectedCategory === label;
 
@@ -30,8 +30,8 @@ const CategoryFilter = ({ selectedCategory, onSelectCategory }: CategoryFilterPr
             className={clsx(
               'flex items-center shrink-0 px-12 py-6 rounded-full border transition-colors duration-200 cursor-pointer whitespace-nowrap',
               isSelected
-                ? 'bg-[#333333] text-white border-primary text-14-m md:text-16-m'
-                : 'bg-white text-gray-950 border-gray-300 text-14-m md:text-16-m',
+                ? 'bg-[#333333] text-white border-primary text-14-m md:text-16-m hover:bg-[#2a2a2a]'
+                : 'bg-white text-gray-950 border-gray-300 text-14-m md:text-16-m hover:bg-gray-100',
             )}
           >
             <Image

--- a/src/components/landing/CategoryFilter.tsx
+++ b/src/components/landing/CategoryFilter.tsx
@@ -26,6 +26,7 @@ const CategoryFilter = ({ selectedCategory, onSelectCategory }: CategoryFilterPr
         return (
           <button
             key={label}
+            aria-pressed={isSelected}
             onClick={() => onSelectCategory(isSelected ? null : label)}
             className={clsx(
               'flex items-center shrink-0 px-12 py-6 rounded-full border transition-colors duration-200 cursor-pointer whitespace-nowrap',

--- a/src/components/landing/LandingCard.tsx
+++ b/src/components/landing/LandingCard.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 
 export interface Activity {
   id?: number;
@@ -11,8 +12,13 @@ export interface Activity {
 
 const LandingCard = ({ activity }: { activity: Activity }) => {
   const { id, bannerImageUrl, title, rating, reviewCount, price } = activity;
+  const router = useRouter();
+
   return (
-    <div className='relative shrink-0 w-[132px] h-[242px] sm:w-[332px] sm:h-[423px] lg:w-[262px] lg:h-[366px] shadow-card rounded-[32px] overflow-hidden'>
+    <div
+      onClick={() => router.push(`/activities/${id}`)}
+      className='relative shrink-0 w-[132px] h-[242px] sm:w-[332px] sm:h-[423px] lg:w-[262px] lg:h-[366px] shadow-card rounded-[32px] overflow-hidden cursor-pointer transition-transform duration-200 hover:scale-105'
+    >
       {/* 이미지 영역 */}
       <div className='relative h-[132px] sm:h-[290px] lg:h-[240px] rounded-t-4xl overflow-hidden'>
         <Image

--- a/src/components/landing/LandingCard.tsx
+++ b/src/components/landing/LandingCard.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 
-interface LandingCardType {
+export interface Activity {
+  id?: number;
   bannerImageUrl?: string;
   title: string;
   rating: number;
@@ -8,7 +9,8 @@ interface LandingCardType {
   price: number;
 }
 
-const LandingCard = ({ bannerImageUrl, title, rating, reviewCount, price }: LandingCardType) => {
+const LandingCard = ({ activity }: { activity: Activity }) => {
+  const { id, bannerImageUrl, title, rating, reviewCount, price } = activity;
   return (
     <div className='relative shrink-0 w-[132px] h-[242px] sm:w-[332px] sm:h-[423px] lg:w-[262px] lg:h-[366px] shadow-card rounded-[32px] overflow-hidden'>
       {/* 이미지 영역 */}

--- a/src/components/landing/LandingCard.tsx
+++ b/src/components/landing/LandingCard.tsx
@@ -17,7 +17,7 @@ const LandingCard = ({ activity }: { activity: Activity }) => {
   return (
     <div
       onClick={() => router.push(`/activities/${id}`)}
-      className='relative shrink-0 w-[132px] h-[242px] sm:w-[332px] sm:h-[423px] lg:w-[262px] lg:h-[366px] shadow-card rounded-[32px] overflow-hidden cursor-pointer transition-transform duration-200 hover:scale-105'
+      className='relative shrink-0 w-[132px] h-[242px] sm:w-[332px] sm:h-[423px] lg:w-[262px] lg:h-[366px] shadow-custom-5 rounded-[32px] overflow-hidden cursor-pointer transition-transform duration-200 hover:scale-105'
     >
       {/* 이미지 영역 */}
       <div className='relative h-[132px] sm:h-[290px] lg:h-[240px] rounded-t-4xl overflow-hidden'>

--- a/src/components/landing/MostCommentedActivities.tsx
+++ b/src/components/landing/MostCommentedActivities.tsx
@@ -35,7 +35,7 @@ const MostCommentedActivities = () => {
       <h2 className='text-20-b md:text-24-b mb-30'>🔥 인기 체험</h2>
       <div className='flex gap-16 sm:gap-24 overflow-x-auto no-scrollbar'>
         {mockData.map((item) => (
-          <LandingCard key={item.id} {...item} />
+          <LandingCard key={item.id} activity={item} />
         ))}
       </div>
     </section>

--- a/src/components/landing/MostCommentedActivities.tsx
+++ b/src/components/landing/MostCommentedActivities.tsx
@@ -33,7 +33,7 @@ const MostCommentedActivities = () => {
   return (
     <section className='mt-80 mb-60 '>
       <h2 className='text-20-b md:text-24-b mb-30'>🔥 인기 체험</h2>
-      <div className='flex gap-16 sm:gap-24 overflow-x-auto no-scrollbar'>
+      <div className='flex gap-16 sm:gap-24 overflow-x-auto no-scrollbar overflow-hidden'>
         {mockData.map((item) => (
           <LandingCard key={item.id} activity={item} />
         ))}

--- a/src/components/landing/SearchBar.tsx
+++ b/src/components/landing/SearchBar.tsx
@@ -25,12 +25,14 @@ const SearchBar = () => {
 
       <div className='relative w-full max-w-[1080px]'>
         {/* 아이콘 */}
-        <span className='absolute left-4 top-1/2 -translate-y-1/2'>
+        <span className='absolute left-6 top-1/2 -translate-y-1/2'>
           <Image src='/icons/icon_search.svg' alt='검색 아이콘' width={24} height={24} />
         </span>
 
         {/* 검색 버튼 */}
         <button
+          aria-label='체험 검색 버튼'
+          type='button'
           onClick={handleSearch}
           className='absolute right-4 top-1/2 -translate-y-1/2 
                      w-[85px] h-[41px] md:w-[120px] md:h-[50px] 
@@ -42,17 +44,15 @@ const SearchBar = () => {
 
         {/* 인풋 필드 */}
         <input
+          aria-label='체험 검색 입력창'
           type='text'
           value={keyword}
           onChange={(e) => setKeyword(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder='내가 원하는 체험은?'
           className='w-full h-53 rounded-[12px] bg-white
-                     pl-[30px] pr-[95px] md:pr-[130px] 
-                     text-gray-500 text-14-m md:h-70 focus:outline-none cursor-pointer'
-          style={{
-            boxShadow: '0px 6px 10px rgba(13, 153, 255, 0.05)',
-          }}
+                     pl-[48px] pr-[95px] md:pr-[130px] 
+                     text-gray-500 text-14-m md:h-70 focus:outline-none shadow-custom-5'
         />
       </div>
     </section>

--- a/src/components/search/NoResult.tsx
+++ b/src/components/search/NoResult.tsx
@@ -1,0 +1,9 @@
+const NoResult = () => {
+  return (
+    <div className='w-full py-150 text-center text-gray-400 text-24-b'>
+      😥 해당 키워드에 대한 체험이 없어요. 다른 키워드로 검색해보세요!
+    </div>
+  );
+};
+
+export default NoResult;


### PR DESCRIPTION


## 🧩 관련 이슈 번호

- 이슈 번호 #47 

## ✨ 요약

<!-- 구현 및 수정한 내용을 간단하게 적어주세요. -->
검색바에 검색 키워드를 입력 후 보여지는 검색결과 페이지 구현 

## 📌 주요 변경 사항

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요. -->
- 검색 결과가 있는 경우, 없는 경우 나뉘어 결과가 보여집니다.
- 현재 목데이터로 테스트 중이라서 결과 없음으로 보이는 중입니다 참고해주세요
- 글로벌css 스크롤 속성 추가했습니다 : 카드 스크롤은 되지만 스크롤바가 보이지 않도록 하기 위함 (scrollbar-no)
- 랜딩카드 체험을 누르면 체험 상세페이지로 이동하는 라우터 설정


## 📷 UI 변경 사항 (선택)

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

<img width="1886" height="1620" alt="image" src="https://github.com/user-attachments/assets/c9396c7b-6d7b-42e0-89d4-5b9c9792e0ae" />


## ❓무슨 문제가 발생했나요 ?

## 💬 논의 사항

<!-- 논의하고 싶은 사항을 적어 주시고, 토론이 필요하시면 토론 탭에 추가 부탁드립니다. -->

## 💬 기타 참고 사항

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->
- 검색결과가 없는 경우는, 인기 체험이 추천으로 보여지는 기능을 추가할까 생각중입니다!


