### PR TITLE
✨Feat: 지도 컴포넌트 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react": "^19.0.0",
     "react-calendar": "^6.0.0",
     "react-dom": "^19.0.0",
+    "react-kakao-maps-sdk": "^1.2.0",
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {
@@ -26,6 +27,7 @@
     "autoprefixer": "^10.4.21",
     "eslint": "^9",
     "eslint-config-next": "15.3.5",
+    "kakao.maps.d.ts": "^0.1.40",
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",
     "prettier-plugin-tailwindcss": "^0.6.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.1.0(react@19.1.0)
+      react-kakao-maps-sdk:
+        specifier: ^1.2.0
+        version: 1.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -54,6 +57,9 @@ importers:
       eslint-config-next:
         specifier: 15.3.5
         version: 15.3.5(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
+      kakao.maps.d.ts:
+        specifier: ^0.1.40
+        version: 0.1.40
       postcss:
         specifier: ^8.5.6
         version: 8.5.6
@@ -79,6 +85,10 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@babel/runtime@7.27.6':
+    resolution: {integrity: sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==}
+    engines: {node: '>=6.9.0'}
 
   '@emnapi/core@1.4.4':
     resolution: {integrity: sha512-A9CnAbC6ARNMKcIcrQwq6HeHCjpcBZ5wSx4U01WXCqEKlrzB9F9315WDNHkrs2xbx7YjjSxbUYxuN6EQzpcY2g==}
@@ -1346,6 +1356,9 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  kakao.maps.d.ts@0.1.40:
+    resolution: {integrity: sha512-nX69MB1ok04epe3OqS+/tEeWBbU31GSQbvDPJmQRRltzzqn6t4jBsO5v1nzalUjCKzwcH2CptOc767NZ7Hbu3g==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -1723,6 +1736,12 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-kakao-maps-sdk@1.2.0:
+    resolution: {integrity: sha512-ptyHhtSbvyza+9IAf6TXjE4ZhwwLbXR6avgNM2ju5xed2+fDwJ+gJDFSqhfsKbvFn9K9+3I+dY3JrqruwsGNBw==}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
     engines: {node: '>=0.10.0'}
@@ -2014,6 +2033,8 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.12
       '@jridgewell/trace-mapping': 0.3.29
+
+  '@babel/runtime@7.27.6': {}
 
   '@emnapi/core@1.4.4':
     dependencies:
@@ -3400,6 +3421,8 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  kakao.maps.d.ts@0.1.40: {}
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -3684,6 +3707,13 @@ snapshots:
       scheduler: 0.26.0
 
   react-is@16.13.1: {}
+
+  react-kakao-maps-sdk@1.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@babel/runtime': 7.27.6
+      kakao.maps.d.ts: 0.1.40
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   react@19.1.0: {}
 

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -3,6 +3,7 @@ import PhotoSection from '@/components/activities/PhotoSection';
 import ReviewCard from '@/components/activities/ReviewCard';
 import DropdownMenu from '@/components/activities/ActivitesDropdown';
 import ReservationContent from '@/components/activities/ReservationFlow/ReservationContent';
+import MapView from '@/components/activities/MapView';
 import Image from 'next/image';
 
 const mock = {
@@ -111,9 +112,7 @@ const ActivityPage = async ({ params }: Props) => {
           <div className='flex flex-col gap-8 border-b-1 border-gray-100'>
             <h3 className='text-18-b text-gray-950'>오시는 길</h3>
             <p className='text-[14px] font-semibold text-gray-950'>{mock.address}</p>
-            <div className='mb-20 h-180 w-auto rounded-2xl bg-gray-100 text-center md:h-400'>
-              임시 지도
-            </div>
+            <MapView address={mock.address} />
           </div>
 
           {/* 체험 후기 */}
@@ -164,9 +163,7 @@ const ActivityPage = async ({ params }: Props) => {
             <div className='flex flex-col gap-8 border-b-1 border-gray-100'>
               <h3 className='text-18-b text-gray-950'>오시는 길</h3>
               <p className='text-[14px] font-semibold text-gray-950'>{mock.address}</p>
-              <div className='mb-20 h-180 w-auto rounded-2xl bg-gray-100 text-center md:h-400'>
-                임시 지도
-              </div>
+              <MapView address={mock.address} />
             </div>
 
             {/* 체험 후기 */}

--- a/src/app/activities/layout.tsx
+++ b/src/app/activities/layout.tsx
@@ -1,9 +1,17 @@
 import { ReactNode } from 'react';
+import Script from 'next/script';
 
 export default function ActivitiesLayout({ children }: { children: ReactNode }) {
   return (
-    <div className='mx-24 my-30 flex flex-col gap-20 md:mx-30 md:my-34 md:gap-30 lg:items-center lg:mx-12 lg:my-88'>
-      {children}
-    </div>
+    <>
+      <div className='mx-24 my-30 flex flex-col gap-20 md:mx-30 md:my-34 md:gap-30 lg:mx-12 lg:my-88 lg:items-center'>
+        {children}
+      </div>
+      <Script
+        type='text/javascript'
+        src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_MAP_API_KEY}&libraries=services,clusterer&autoload=false`}
+        strategy='beforeInteractive'
+      />
+    </>
   );
 }

--- a/src/components/activities/MapView.tsx
+++ b/src/components/activities/MapView.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { Map, MapMarker, CustomOverlayMap } from 'react-kakao-maps-sdk';
 import { useEffect, useState } from 'react';
+import axios from 'axios';
 import Link from 'next/link';
 
 interface MapViewProps {
@@ -25,13 +26,29 @@ const MapView = ({ address = DEFAULT_ADDRESS }: MapViewProps) => {
   });
 
   useEffect(() => {
-    // 실제 API는 아직 안 붙고, 서울시청 정보만 하드코딩해서 상태 주입
-    setPlace({
-      lat: 37.5665,
-      lng: 126.978,
-      title: '서울시청',
-      url: 'https://map.kakao.com/',
-    });
+    const fetchData = async (query: string) => {
+      const KEY = process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY;
+      const URL = `https://dapi.kakao.com/v2/local/search/keyword.json?page=1&size=1&query=${query}`;
+      try {
+        const response = await axios.get(URL, {
+          headers: {
+            Authorization: `KakaoAK ${KEY}`,
+          },
+        });
+
+        const found = response.data.documents[0];
+        setPlace({
+          lat: Number(found.y),
+          lng: Number(found.x),
+          title: found.place_name,
+          url: found.place_url,
+        });
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    fetchData(address);
   }, [address]);
 
   return (

--- a/src/components/activities/MapView.tsx
+++ b/src/components/activities/MapView.tsx
@@ -36,6 +36,20 @@ const MapView = ({ address = DEFAULT_ADDRESS }: MapViewProps) => {
           },
         });
 
+        // 주소는 넘어오지만 인식 하지 못한 경우
+        if (Array.isArray(response.data.documents) && response.data.documents.length === 0) {
+          // Kakao API가 번지 포함 도로명 주소를 인식하지 못하는 경우가 있어 번지 제거 후 재시도
+          const partialAddress = address.replace(/\s\d+(-\d+)?$/g, '').trim();
+          console.log(partialAddress);
+          if (partialAddress !== query) {
+            fetchData(partialAddress); // 재귀로 partialAddress 검색
+          } else {
+            console.log('주소를 가져오는데 실패하였습니다.');
+            fetchData(DEFAULT_ADDRESS); // 여기서 DEFAULT_ADDRESS 직접 사용
+          }
+          return;
+        }
+
         const found = response.data.documents[0];
         setPlace({
           lat: Number(found.y),

--- a/src/components/activities/MapView.tsx
+++ b/src/components/activities/MapView.tsx
@@ -1,0 +1,57 @@
+'use client';
+import { Map, MapMarker, CustomOverlayMap } from 'react-kakao-maps-sdk';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+interface MapViewProps {
+  address: string;
+}
+
+interface Place {
+  lat: number;
+  lng: number;
+  title: string;
+  url: string;
+}
+
+const DEFAULT_ADDRESS = '서울 중구 세종대로 110'; // 서울시청
+
+const MapView = ({ address = DEFAULT_ADDRESS }: MapViewProps) => {
+  const [place, setPlace] = useState<Place>({
+    lat: 0,
+    lng: 0,
+    title: '',
+    url: '',
+  });
+
+  useEffect(() => {
+    // 실제 API는 아직 안 붙고, 서울시청 정보만 하드코딩해서 상태 주입
+    setPlace({
+      lat: 37.5665,
+      lng: 126.978,
+      title: '서울시청',
+      url: 'https://map.kakao.com/',
+    });
+  }, [address]);
+
+  return (
+    <div className='mb-20 h-180 w-auto overflow-hidden rounded-2xl md:h-400'>
+      <Map
+        center={{ lat: place.lat, lng: place.lng }}
+        style={{ width: '100%', height: '100%' }}
+        level={2}
+      >
+        <MapMarker position={{ lat: place.lat, lng: place.lng }} />
+        <CustomOverlayMap position={{ lat: place.lat, lng: place.lng }} yAnchor={1}>
+          <div className='relative bottom-50 flex h-40 w-auto items-center rounded-2xl bg-white p-10 shadow-md'>
+            <Link className='flex' href={place.url} target='_blank'>
+              <span className='text-14-m text-gray-950'>{place.title}</span>
+            </Link>
+          </div>
+        </CustomOverlayMap>
+      </Map>
+    </div>
+  );
+};
+
+export default MapView;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     ],
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "types": ["kakao.maps.d.ts"]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #62

## ✨ 요약

<!-- 구현 및 수정한 내용을 간단하게 적어주세요. -->
-  KAKAO MAP을 연동하여 지도 컴포넌트를 구현 했습니다.

## 📌 주요 변경 사항

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요. -->
## `layout.tsx`
- 체험 상세 페이지에만 사용하고 있기 때문에 해당 스크립트를 상세 페이지에만 넣었습니다.
- Kakao Map SDK를 연동하였습니다.
- `strategy="beforeInteractive"`을 사용하여 Hydration 되기 전에 로드가 되도록 설정했습니다.
- `NEXT_PUBLIC_KAKAO_MAP_API_KEY` 환경 변수를 추가하였습니다.
```tsx
     <Script
        type='text/javascript'
        src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_MAP_API_KEY}&libraries=services,clusterer&autoload=false`}
        strategy='beforeInteractive'
      />
```
## `MapView.tsx`
- react-kakao-maps-sdk 라이브러리를 이용하여 구현 하였습니다.
```tsx
'use client';
import { Map, MapMarker, CustomOverlayMap } from 'react-kakao-maps-sdk';

//...
      <Map
        center={{ lat: place.lat, lng: place.lng }}
        style={{ width: '100%', height: '100%' }}
        level={2}
      >
        <MapMarker position={{ lat: place.lat, lng: place.lng }} /> 
        <CustomOverlayMap position={{ lat: place.lat, lng: place.lng }} yAnchor={1}>
          <div className='relative bottom-50 flex h-40 w-auto items-center rounded-2xl bg-white p-10 shadow-md'>
            <Link className='flex' href={place.url} target='_blank'>
              <span className='text-14-m text-gray-950'>{place.title}</span>
            </Link>
          </div>
        </CustomOverlayMap>
      </Map>
  );
};

export default MapView;
```
| 컴포넌트               | 역할                     |
|--------------------|--------------------------|
| `Map`              | 지도 생성                |
| `MapMarker`        | 지도 마커 생성           |
| `CustomOverlayMap` | 커스텀 오버레이 생성     |

## 📷 UI 변경 사항 (선택)

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->
<img width="820" height="486" alt="image" src="https://github.com/user-attachments/assets/eec1e318-8a7f-4d58-8fcb-32163f25d32c" />

## 마커 상단 오버레이 클릭 시
- 클릭 시 새 탭으로 나오게 구현하였습니다.

https://github.com/user-attachments/assets/ac909fc6-2275-492c-aae9-7eff6f296fc9



## ❓무슨 문제가 발생했나요 ?
**1. Kakao Map 자체 타입이 존재하지 않아 찾아본 결과 kakao는 따로 타입이 없어서 any로 선언 해야 하는 문제가 있었습니다.**

**🛠️ 해결 방법**

- 저희는 따로 any를 사용 할 시 오류를 반환하도록 설정 되어 있어서 자체 구현을 진행하지 못했습니다.
- 찾아보니 react-kakao-maps-sdk 라이브러리에는 해당 타입도 같이 들어있고 해당 타입 패키지만 받아서 자체 구현을 진행할 수 있었지만 그러면 구현이 더 늦어질 거 같아서 해당 라이브러리를 도입하였습니다.


**2. Kakao API가 번지(예: `13-1`)가 포함된 도로명 주소를 제대로 검색하지 못해 빈 배열을 반환하는 문제가 있었습니다.**

**🛠️ 해결 방법**

- 정규식을 활용해 주소에서 번지 정보를 제거한 후 재검색을 시도했습니다.
- 그래도 검색 결과가 없는 경우, 기본 주소(`서울 중구 세종대로 110`)로 fallback 처리하였습니다.

## 💬 논의 사항

<!-- 논의하고 싶은 사항을 적어 주시고, 토론이 필요하시면 토론 탭에 추가 부탁드립니다. -->

### 이제 다들 페이지에 API에 연결하다 보니 저희 로그인 방식을 어떤 방식으로 할 지 확정을 해야 페이지 렌더링 방식도 선택할 수 있을 거 같습니다! (인터렉션이 많은 부분은 CSR로 구성하셔도 무방 합니다)

1. 기존 방식 유지 (로컬 스토리지) = CSR
- NEXT의 SSR을 결국 서버와 서버의 연결을 통해서 미리 데이터를 받아오는 것인데 로컬 스토리지 사용 시 서버 자체에 `window` 객체가 없기 때문에 결국 사용하지 못합니다. 
- 만약 SSR을 도입 하고 싶을 경우에는 저번에 이슈로 남았던 쿠키의 CORS 에러 #38 를 해결해야 사용할 수 있을 거 같습니다. (이 부분은 정확히 어떤 오류 였는지 말씀해주세요!)

2. 쿠키로 변경 = SSR or SSG(랜딩, 메인, 체험 상세 )
- 저희 백엔드 서버가 쿠키 자체를 막았는지 파악하지 못하여 만약 변경 할 경우 어떤 문제인지 찾아볼 거 같습니다. 
- 변경 할 경우 최상위 `layout.tsx` 에 `"use clinet"` 선언을 빼야 할 거 같습니다. (현재 최상위에 선언 되어 있어서 전부 클라이언트 컴포넌트로 동작)



## 💬 기타 참고 사항

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->
- KAKAO MAP, KAKAO REST API에 대한 API KEY를 환경 변수로 설정해두었습니다 해당 부분은 따로 말씀드리겠습니다!