### PR TITLE
🐛Fix: 리프레시 토큰 기반 accessToken 재발급 로직 구현 (401 Error)

### DIFF
--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -1,7 +1,5 @@
-// lib/api/auth.ts
-// loginApi 함수 → 로그인 요청을 보내고, 성공 시 accessToken, refreshToken, user 정보를 반환하도록
-// signupApi 함수 → 회원가입 요청을 보내고, 성공 시 사용자 정보를 반환
 import instance from './axios';
+import axios from 'axios';
 
 interface LoginPayload {
   email: string;
@@ -15,11 +13,36 @@ interface SignupPayload {
 }
 
 export const loginApi = async ({ email, password }: LoginPayload) => {
-  const response = await instance.post('/auth/login', { email, password });
-  return response.data; // accessToken, refreshToken, user 포함됨
+  const res = await instance.post('/auth/login', { email, password });
+  return res.data;
 };
 
 export const signupApi = async (data: SignupPayload) => {
-  const response = await instance.post('/users', data);
-  return response.data;
+  const res = await instance.post('/users', data);
+  return res.data;
+};
+
+export const refreshAccessToken = async (): Promise<string> => {
+  const refreshToken = localStorage.getItem('refreshToken');
+  if (!refreshToken) {
+    throw new Error('리프레시 토큰이 없습니다');
+  }
+
+  const res = await axios.post(
+    '/auth/tokens',
+    {},
+    {
+      baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
+      headers: {
+        Authorization: `Bearer ${refreshToken}`,
+      },
+    },
+  );
+
+  const { accessToken, refreshToken: newRefreshToken } = res.data;
+
+  localStorage.setItem('accessToken', accessToken);
+  localStorage.setItem('refreshToken', newRefreshToken);
+
+  return accessToken;
 };


### PR DESCRIPTION

## 🧩 관련 이슈 번호

- 이슈 번호 #81 

## ✨ 요약

<!-- 구현 및 수정한 내용을 간단하게 적어주세요. -->

401 응답 시 리프레시 토큰으로 accessToken 재발급 처리
- 모든 axios 요청 헤더에 accessToken 자동 주입
- 코드 가독성을 위해 변수명 통일 (response → res)

## 📌 주요 변경 사항

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요. -->
- axios 인터셉터에 401 응답 처리 로직 추가
- refreshAccessToken 함수 작성하여 accessToken 재발급 처리
- 기존 요청 재시도 및 실패 시 로그아웃 처리
- 통신 실패 시 서버 응답을 그대로 throw하여 클라이언트가 대응 가능하도록 처리

##❓ 문제 원인 및 해결
- /my-info, /my-notifications API 호출 시 401 에러 발생
   원인: accessToken 만료
   해결: 리프레시 토큰을 이용한 accessToken 재발급 로직 구현

## 💬 논의 사항

<!-- 논의하고 싶은 사항을 적어 주시고, 토론이 필요하시면 토론 탭에 추가 부탁드립니다. -->
현재는 로컬스토리지 기반으로 access/refresh 토큰을 관리하고 있음

## 💬 기타 참고 사항

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

useRouter().push('/login') 대신 window.location.href = '/login' 사용
→ Axios 인터셉터는 React 컴포넌트 외부(lib/api/axios.ts)에서 실행되기 때문에
→ React Hook(useRouter) 사용 불가
→ 리다이렉트 시에는 window.location.href 방식이 더 안전하게 작동함

