### PR TITLE
✨Feat: 알림 컴포넌트 구현 

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useState, useEffect } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import Dropdown from './Dropdown/Dropdown';
+import NotiBell from './Notification/NotiBell';
 import clsx from 'clsx';
 
 const Header = () => {
@@ -65,13 +66,7 @@ const Header = () => {
         {user ? (
           <div className='relative flex items-center gap-4'>
             {/* 알림 아이콘 */}
-            <Image
-              src={hasNewNotification ? '/icons/icon_bell_on.svg' : '/icons/icon_bell_off.svg'}
-              alt='알림'
-              width={24}
-              height={24}
-              className='cursor-pointer text-gray-600 transition-opacity duration-200 hover:opacity-80'
-            />
+            <NotiBell />
             {/* 구분선 */}
             <div className='h-14 w-px bg-gray-200' />
 

--- a/src/components/common/Notification/NotiBell.tsx
+++ b/src/components/common/Notification/NotiBell.tsx
@@ -1,7 +1,8 @@
 //알림 벨 아이콘 컴포넌트
 'use client';
 
-import { useState, useRef } from 'react';
+import axios from '@/lib/api/axios';
+import { useState, useRef, useEffect } from 'react';
 import Image from 'next/image';
 import NotiList from './NotiList';
 import clsx from 'clsx';
@@ -10,6 +11,24 @@ const NotiBell = () => {
   const [open, setOpen] = useState(false);
   const [hasNewNotification, setHasNewNotification] = useState(false);
   const bellRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const checkNotifications = async () => {
+      try {
+        const token = localStorage.getItem('accessToken');
+        if (!token) return;
+
+        const res = await axios.get('/my-notifications');
+        if (res.data.totalCount > 0) {
+          setHasNewNotification(true);
+        }
+      } catch (err) {
+        console.error('알림 확인 실패:', err);
+      }
+    };
+
+    checkNotifications();
+  }, []);
 
   return (
     <div ref={bellRef} className='relative'>
@@ -22,7 +41,7 @@ const NotiBell = () => {
         onClick={() => setOpen((prev) => !prev)}
         className={clsx(
           'cursor-pointer transition-opacity duration-200 hover:opacity-80',
-          open && 'text-primary-500',
+          open && 'text-primary-500 brightness-0 saturate-100 filter',
         )}
       />
 

--- a/src/components/common/Notification/NotiBell.tsx
+++ b/src/components/common/Notification/NotiBell.tsx
@@ -1,0 +1,41 @@
+//알림 벨 아이콘 컴포넌트
+'use client';
+
+import { useState, useRef } from 'react';
+import Image from 'next/image';
+import NotiList from './NotiList';
+import clsx from 'clsx';
+
+const NotiBell = () => {
+  const [open, setOpen] = useState(false);
+  const bellRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <div ref={bellRef} className='relative'>
+      {/* 알림 아이콘 */}
+      <Image
+        src={hasNewNotification ? '/icons/icon_bell_on.svg' : '/icons/icon_bell_off.svg'}
+        alt='알림'
+        width={24}
+        height={24}
+        onClick={() => setOpen((prev) => !prev)}
+        className={clsx(
+          'cursor-pointer transition-opacity duration-200 hover:opacity-80',
+          open && 'text-primary-500',
+        )}
+      />
+
+      {/* 배경 오버레이 */}
+      {open && <div className='fixed inset-0 z-40 bg-black/10' onClick={() => setOpen(false)} />}
+
+      {/* 알림 목록 드롭다운 */}
+      {open && (
+        <div className='absolute z-50'>
+          <NotiList />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default NotiBell;

--- a/src/components/common/Notification/NotiBell.tsx
+++ b/src/components/common/Notification/NotiBell.tsx
@@ -8,6 +8,7 @@ import clsx from 'clsx';
 
 const NotiBell = () => {
   const [open, setOpen] = useState(false);
+  const [hasNewNotification, setHasNewNotification] = useState(false);
   const bellRef = useRef<HTMLDivElement>(null);
 
   return (

--- a/src/components/common/Notification/NotiBell.tsx
+++ b/src/components/common/Notification/NotiBell.tsx
@@ -38,7 +38,9 @@ const NotiBell = () => {
         alt='알림'
         width={24}
         height={24}
-        onClick={() => setOpen((prev) => !prev)}
+        onClick={() => {
+          setOpen((prev) => !prev);
+        }}
         className={clsx(
           'cursor-pointer transition-opacity duration-200 hover:opacity-80',
           open && 'text-primary-500 brightness-0 saturate-100 filter',
@@ -50,8 +52,8 @@ const NotiBell = () => {
 
       {/* 알림 목록 드롭다운 */}
       {open && (
-        <div className='absolute z-50'>
-          <NotiList />
+        <div className='fixed top-[60px] left-1/2 z-50 -translate-x-1/2 sm:absolute sm:top-full sm:right-0 sm:left-auto sm:mt-12 sm:translate-x-0'>
+          <NotiList setHasNewNotification={setHasNewNotification} />
         </div>
       )}
     </div>

--- a/src/components/common/Notification/NotiItem.tsx
+++ b/src/components/common/Notification/NotiItem.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import Image from 'next/image';
+import { formatDistanceToNow } from 'date-fns';
+import { ko } from 'date-fns/locale';
+
+interface NotiItemProps {
+  id: number;
+  content: string;
+  createdAt: string;
+  onDelete: () => void;
+  onClick: () => void;
+}
+
+const renderContent = (content: string) => {
+  const highlight = (word: string, className: string) => {
+    const [before, after] = content.split(word);
+    return (
+      <>
+        {before}
+        <span className={className}>{word}</span>
+        {after}
+      </>
+    );
+  };
+
+  if (content.includes('승인')) return highlight('승인', 'text-primary-500');
+  if (content.includes('거절')) return highlight('거절', 'text-red');
+  return content;
+};
+
+const NotiItem = ({ content, createdAt, onDelete, onClick }: NotiItemProps) => {
+  return (
+    <div
+      className='flex w-full cursor-pointer items-start justify-between px-12 py-12 sm:px-16 sm:py-20'
+      onClick={onClick}
+    >
+      {/* 왼쪽: 내용 + 시간 */}
+      <div className='flex min-w-0 flex-grow flex-col gap-4'>
+        <span className='text-14-m break-words'>{renderContent(content)}</span>
+        <span className='text-12-m text-gray-400'>
+          {formatDistanceToNow(new Date(createdAt), {
+            addSuffix: true,
+            locale: ko,
+          })}
+        </span>
+      </div>
+
+      {/* 오른쪽: 삭제 아이콘 */}
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onDelete();
+        }}
+        className='ml-8 shrink-0'
+      >
+        <Image src='/icons/icon_delete.svg' alt='삭제' width={24} height={24} />
+      </button>
+    </div>
+  );
+};
+
+export default NotiItem;

--- a/src/components/common/Notification/NotiList.tsx
+++ b/src/components/common/Notification/NotiList.tsx
@@ -12,6 +12,9 @@ interface NotificationType {
   content: string;
   createdAt: string;
 }
+interface NotiListProps {
+  setHasNewNotification?: (val: boolean) => void;
+}
 
 const fetchNotifications = async () => {
   const token = localStorage.getItem('accessToken');
@@ -26,7 +29,7 @@ const deleteNotification = async (notificationId: number) => {
   await axios.delete(`/my-notifications/${notificationId}`);
 };
 
-const NotiList = () => {
+const NotiList = ({ setHasNewNotification }: NotiListProps) => {
   const [notifications, setNotifications] = useState<NotificationType[]>([]);
   const [totalCount, setTotalCount] = useState(0);
 
@@ -41,7 +44,13 @@ const NotiList = () => {
   const handleDelete = async (id: number) => {
     try {
       await deleteNotification(id);
-      setNotifications((prev) => prev.filter((item) => item.id !== id));
+      setNotifications((prev) => {
+        const newList = prev.filter((item) => item.id !== id);
+        if (newList.length === 0 && setHasNewNotification) {
+          setHasNewNotification(false);
+        }
+        return newList;
+      });
       setTotalCount((prev) => prev - 1);
     } catch (err: any) {
       const message = err?.response?.data?.message || '알림 삭제에 실패했습니다.';
@@ -56,9 +65,7 @@ const NotiList = () => {
   return (
     <div
       className={clsx(
-        'absolute top-full left-1/2 mt-12 -translate-x-1/2',
-        'sm:right-0 sm:left-auto sm:translate-x-0',
-        'z-50 w-[92vw] max-w-[360px] rounded-[12px] bg-white shadow-lg transition-all',
+        'w-[92vw] max-w-[320px] rounded-[12px] bg-white shadow-lg transition-all',
         'max-h-[360px] overflow-y-auto',
       )}
     >

--- a/src/components/common/Notification/NotiList.tsx
+++ b/src/components/common/Notification/NotiList.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import NotiItem from './NotiItem';
+import clsx from 'clsx';
+import axios from '@/lib/api/axios';
+import NotiNull from './NotiNull';
+
+interface NotificationType {
+  id: number;
+  content: string;
+  createdAt: string;
+}
+
+const fetchNotifications = async () => {
+  const token = localStorage.getItem('accessToken');
+  if (!token) {
+    return { notifications: [], totalCount: 0 };
+  }
+  const res = await axios.get('/my-notifications');
+  return res.data;
+};
+
+const deleteNotification = async (notificationId: number) => {
+  await axios.delete(`/my-notifications/${notificationId}`);
+};
+
+const NotiList = () => {
+  const [notifications, setNotifications] = useState<NotificationType[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+
+  const router = useRouter();
+
+  const loadNotifications = async () => {
+    const data = await fetchNotifications();
+    setNotifications(data.notifications);
+    setTotalCount(data.totalCount);
+  };
+
+  const handleDelete = async (id: number) => {
+    try {
+      await deleteNotification(id);
+      setNotifications((prev) => prev.filter((item) => item.id !== id));
+      setTotalCount((prev) => prev - 1);
+    } catch (err: any) {
+      const message = err?.response?.data?.message || '알림 삭제에 실패했습니다.';
+      alert(message);
+    }
+  };
+
+  useEffect(() => {
+    loadNotifications();
+  }, []);
+
+  return (
+    <div
+      className={clsx(
+        'absolute top-full left-1/2 mt-12 -translate-x-1/2',
+        'sm:right-0 sm:left-auto sm:translate-x-0',
+        'z-50 w-[92vw] max-w-[360px] rounded-[12px] bg-white shadow-lg transition-all',
+        'max-h-[360px] overflow-y-auto',
+      )}
+    >
+      <h3 className='text-16-b border-b border-gray-100 px-16 pt-16 pb-8 text-gray-950 sm:px-16'>
+        알림 {totalCount}개
+      </h3>
+
+      <ul className='flex flex-col'>
+        {notifications.length === 0 ? (
+          <NotiNull />
+        ) : (
+          notifications.map((noti) => (
+            <li
+              key={noti.id}
+              className='hover:bg-primary-100 rounded-[6px] transition-colors duration-150'
+            >
+              <NotiItem
+                id={noti.id}
+                content={noti.content}
+                createdAt={noti.createdAt}
+                onDelete={() => handleDelete(noti.id)}
+                onClick={() => router.push('/profile/reservations')}
+              />
+            </li>
+          ))
+        )}
+      </ul>
+    </div>
+  );
+};
+
+export default NotiList;

--- a/src/components/common/Notification/NotiNull.tsx
+++ b/src/components/common/Notification/NotiNull.tsx
@@ -1,0 +1,5 @@
+const NotiNull = () => {
+  return <div className='py-40 text-center text-sm text-gray-400'>도착한 알림이 없어요!</div>;
+};
+
+export default NotiNull;


### PR DESCRIPTION


## 🧩 관련 이슈 번호

- 이슈 번호 #72 

## ✨ 요약

<!-- 구현 및 수정한 내용을 간단하게 적어주세요. -->
알림 기능 구현 UI & API 연동

## 📌 주요 변경 사항

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요. -->

- **알림 종류**: 예약 승인 / 예약 거절
- **정렬 기준**: 최신순 정렬
- **드롭다운 위치**
  - 모바일: 화면 중앙 `fixed`
  - PC 이상: 벨 아이콘 기준 `absolute` + 여백
- **알림 버튼 클릭 시**: 알림 내역 드롭다운 표시
- **`X` 버튼 클릭 시**: 해당 알림 삭제 (아직 더 테스트 필요-> 나중에 수정하겠습니다)
- **알림 클릭 시**: 예약 내역 페이지(`/profile/reservations`)로 이동
- **알림 없음**: "도착한 알림이 없어요!" 메시지 노출 (`NotiNull.tsx`)



## 📷 UI 변경 사항 (선택)

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->
- 목데이터 예시
<img width="484" height="686" alt="image" src="https://github.com/user-attachments/assets/0c1193ca-55cd-41a6-8399-49b925826d87" />

- 알람이 없는 경우

<img width="484" height="686" alt="image" src="https://github.com/user-attachments/assets/2adca367-7c0c-4779-8b29-ed4e85616692" />

- 데스크탑
 <img width="1368" height="490" alt="image" src="https://github.com/user-attachments/assets/7e1c7f65-d889-43e7-8880-e64473e20d07" />




## ❓무슨 문제가 발생했나요 ?

## 💬 논의 사항

<!-- 논의하고 싶은 사항을 적어 주시고, 토론이 필요하시면 토론 탭에 추가 부탁드립니다. -->

## 💬 기타 참고 사항

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

- 일단 알림 `X`버튼 누르면 개별 알람 삭제까지 되도록 했는데 추후 수정하려고 합니다.  
- 알람 바깥 터치나 클릭시 닫히도록 구현했는데 닫기 버튼&페이지 이동 시 닫히는 기능도 추가할까 생각중입니다!

