### PR TITLE
🔧Chore: eslint-plugin-react-hooks 누락으로 리뷰 도구 오류 발생 수정 

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "autoprefixer": "^10.4.21",
     "eslint": "^9",
     "eslint-config-next": "15.3.5",
+    "eslint-plugin-react-hooks": "^5.2.0",
     "kakao.maps.d.ts": "^0.1.40",
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@types/lodash": "^4.17.20",
     "@types/node": "^20",
     "@types/react": "^19",
-    "@types/react-calendar": "^4.1.0",
     "@types/react-dom": "^19",
     "autoprefixer": "^10.4.21",
     "eslint": "^9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,9 +57,6 @@ importers:
       '@types/react':
         specifier: ^19
         version: 19.1.8
-      '@types/react-calendar':
-        specifier: ^4.1.0
-        version: 4.1.0(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@types/react-dom':
         specifier: ^19
         version: 19.1.6(@types/react@19.1.8)
@@ -502,10 +499,6 @@ packages:
 
   '@types/node@20.19.4':
     resolution: {integrity: sha512-OP+We5WV8Xnbuvw0zC2m4qfB/BJvjyCwtNjhHdJxV1639SGSKrLmJkc3fMnp2Qy8nJyHp8RO6umxELN/dS1/EA==}
-
-  '@types/react-calendar@4.1.0':
-    resolution: {integrity: sha512-CZL0+bOJ43+ZxnScd6n6SbA3RvoT/FurMIKevvTnRhLdncTRO7LyvBaFu3Bmwoad8ApVBJsMyAiPO79vGWRbbA==}
-    deprecated: This is a stub types definition. react-calendar provides its own type definitions, so you do not need this installed.
 
   '@types/react-dom@19.1.6':
     resolution: {integrity: sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==}
@@ -2410,14 +2403,6 @@ snapshots:
   '@types/node@20.19.4':
     dependencies:
       undici-types: 6.21.0
-
-  '@types/react-calendar@4.1.0(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      react-calendar: 6.0.0(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react
-      - react-dom
 
   '@types/react-dom@19.1.6(@types/react@19.1.8)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       eslint-config-next:
         specifier: 15.3.5
         version: 15.3.5(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
+      eslint-plugin-react-hooks:
+        specifier: ^5.2.0
+        version: 5.2.0(eslint@9.30.1(jiti@2.4.2))
       kakao.maps.d.ts:
         specifier: ^0.1.40
         version: 0.1.40


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #108 

## ✨ 요약

<!-- 구현 및 수정한 내용을 간단하게 적어주세요. -->
- 일부 린트 누락으로 인해 코드래빗이 시각화 자료를 만들기 전에 중단 되는 현상이 있어서 추가 하였습니다.
- 리액트 캘린더 패키지 자체에 타입이 포함 되어 있어 리액트 캘린더 타입을 삭제했습니다.

## ❓무슨 문제가 발생했나요 ?
- 캘린더 자체에 타입이 포함되어 있지만 혹시 오류 생기면 말씀해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 불필요한 "@types/react-calendar" 개발 의존성을 제거했습니다.
  * "eslint-plugin-react-hooks" 개발 의존성을 추가하여 코드 품질 도구를 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->