### PR TITLE
✨Feat: 카카오 간편로그인 구현 Kakao Oauth 

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -8,6 +8,7 @@ import ConfirmModal from '@/components/common/ConfirmModal';
 import { useRouter } from 'next/navigation';
 import { loginApi } from '@/lib/api/auth';
 import { useAuthStore } from '@/store/useAuthStore';
+import { redirectToKakaoOAuth } from '@/lib/utils/kakao';
 
 const LoginPage = () => {
   const { setAccessToken, setRefreshToken, setUser } = useAuthStore();
@@ -58,6 +59,10 @@ const LoginPage = () => {
 
       setIsModalOpen(true); // 모달 오픈
     }
+  };
+
+  const handleKakaoLogin = () => {
+    redirectToKakaoOAuth();
   };
 
   return (
@@ -124,7 +129,10 @@ const LoginPage = () => {
         </div>
 
         {/* 카카오 로그인 */}
-        <button className='text-16-m flex h-48 w-full cursor-pointer items-center justify-center rounded-[16px] border border-gray-300 text-gray-600 transition-colors duration-200 hover:bg-gray-100'>
+        <button
+          onClick={handleKakaoLogin}
+          className='text-16-m flex h-48 w-full cursor-pointer items-center justify-center rounded-[16px] border border-gray-300 text-gray-600 transition-colors duration-200 hover:bg-gray-100'
+        >
           <img src='/icons/icon_kakao.svg' alt='kakaoicon' className='mr-8 h-20 w-20' />
           카카오 로그인
         </button>

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -44,7 +44,6 @@ const LoginPage = () => {
       setAccessToken(accessToken);
       setRefreshToken(refreshToken);
       setUser(user);
-      window.dispatchEvent(new Event('user-update'));
 
       // 성공 시 이동, 에러 시 모달
       router.push('/');

--- a/src/app/(auth)/oauth/kakao/page.tsx
+++ b/src/app/(auth)/oauth/kakao/page.tsx
@@ -1,0 +1,47 @@
+'use client';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import instance from '@/lib/api/axios';
+import { useAuthStore } from '@/store/useAuthStore';
+
+const KakaoCallbackPage = () => {
+  const router = useRouter();
+  const setAccessToken = useAuthStore((state) => state.setAccessToken);
+  const setRefreshToken = useAuthStore((state) => state.setRefreshToken);
+
+  const setUser = useAuthStore((state) => state.setUser);
+
+  useEffect(() => {
+    const fetchKakaoToken = async () => {
+      const code = new URL(window.location.href).searchParams.get('code');
+      if (!code) return;
+
+      try {
+        const loginRes = await instance.post('oauth/sign-in/kakao', {
+          token: code,
+          redirectUri: process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI,
+        });
+
+        const { accessToken, refreshToken, user } = loginRes.data;
+        setAccessToken(accessToken);
+        setRefreshToken(refreshToken);
+
+        setUser(user);
+
+        router.replace('/');
+      } catch (err: any) {
+        if (err?.response?.status === 404) {
+          router.replace(`/oauth/kakao/signup?code=${code}`);
+        } else {
+          alert('카카오 로그인 실패');
+        }
+      }
+    };
+
+    fetchKakaoToken();
+  }, [router, setAccessToken, setRefreshToken, setUser]);
+
+  return <div>카카오 로그인 처리 중...</div>;
+};
+
+export default KakaoCallbackPage;

--- a/src/app/(auth)/oauth/kakao/page.tsx
+++ b/src/app/(auth)/oauth/kakao/page.tsx
@@ -28,9 +28,9 @@ const KakaoCallbackPage = () => {
 
         setUser(user);
 
-        router.replace('/');
+        router.push('/');
       } catch (err: any) {
-        if (err?.response?.status === 404) {
+        if ([403, 404].includes(err?.response?.status)) {
           router.replace(`/oauth/kakao/signup?code=${code}`);
         } else {
           alert('카카오 로그인 실패');

--- a/src/app/(auth)/oauth/kakao/page.tsx
+++ b/src/app/(auth)/oauth/kakao/page.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import instance from '@/lib/api/axios';
 import { useAuthStore } from '@/store/useAuthStore';
+import Image from 'next/image';
 
 const KakaoCallbackPage = () => {
   const router = useRouter();
@@ -41,7 +42,20 @@ const KakaoCallbackPage = () => {
     fetchKakaoToken();
   }, [router, setAccessToken, setRefreshToken, setUser]);
 
-  return <div>카카오 로그인 처리 중...</div>;
+  return (
+    <main className='flex min-h-screen w-full flex-col items-center justify-start bg-white px-4 pt-[25vh]'>
+      <Image
+        src='/icons/logoHorizon.svg'
+        alt='Logo'
+        width={255}
+        height={255}
+        className='mb-6 h-[120] w-[120] animate-bounce object-contain sm:h-[255] sm:w-[255]'
+      />
+
+      <h2 className='text-18-b mb-2 text-gray-800'>카카오 로그인 처리 중...</h2>
+      <p className='text-14-m text-gray-500'>잠시만 기다려주세요 😊</p>
+    </main>
+  );
 };
 
 export default KakaoCallbackPage;

--- a/src/app/(auth)/oauth/kakao/signup/page.tsx
+++ b/src/app/(auth)/oauth/kakao/signup/page.tsx
@@ -42,7 +42,7 @@ const KakaoSignupPage = () => {
 
       setUser(user);
 
-      router.replace('/');
+      router.push('/');
     } catch (error: any) {
       const serverMessage = error?.response?.data?.message ?? '회원가입에 실패했습니다.';
       setErrorMessage(serverMessage);

--- a/src/app/(auth)/oauth/kakao/signup/page.tsx
+++ b/src/app/(auth)/oauth/kakao/signup/page.tsx
@@ -1,0 +1,85 @@
+'use client';
+import { useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import instance from '@/lib/api/axios';
+import Input from '@/components/common/Input';
+import ConfirmModal from '@/components/common/ConfirmModal';
+import { useAuthStore } from '@/store/useAuthStore';
+
+const KakaoSignupPage = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const code = searchParams.get('code');
+
+  const setAccessToken = useAuthStore((state) => state.setAccessToken);
+  const setRefreshToken = useAuthStore((state) => state.setRefreshToken);
+
+  const setUser = useAuthStore((state) => state.setUser);
+
+  const [nickname, setNickname] = useState('');
+  const [nicknameError, setNicknameError] = useState('');
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const validateNickname = (value: string) => {
+    setNicknameError(value.length <= 10 ? '' : '10자 이하로 입력해주세요.');
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!code || !nickname || nicknameError) return;
+
+    try {
+      const res = await instance.post('oauth/sign-up/kakao', {
+        token: code,
+        nickname,
+        redirectUri: process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI,
+      });
+
+      const { accessToken, refreshToken, user } = res.data;
+      setAccessToken(accessToken);
+      setRefreshToken(refreshToken);
+
+      setUser(user);
+
+      router.replace('/');
+    } catch (error: any) {
+      const serverMessage = error?.response?.data?.message ?? '회원가입에 실패했습니다.';
+      setErrorMessage(serverMessage);
+      setIsModalOpen(true);
+    }
+  };
+
+  return (
+    <main className='flex min-h-screen items-start justify-center px-1 pt-60'>
+      <ConfirmModal
+        isOpen={isModalOpen}
+        message={errorMessage}
+        onClose={() => setIsModalOpen(false)}
+      />
+      <form
+        onSubmit={handleSubmit}
+        className='rounded-16 w-full max-w-376 space-y-24 bg-white p-24 md:max-w-640 md:p-32'
+      >
+        <h2 className='text-20-b text-center'>닉네임 입력</h2>
+        <Input
+          label='닉네임'
+          value={nickname}
+          onChange={(e) => setNickname(e.target.value)}
+          onBlur={(e) => validateNickname(e.target.value)}
+          error={nicknameError}
+          placeholder='닉네임을 입력해주세요'
+        />
+        <button
+          type='submit'
+          className='text-16-m bg-primary-500 h-48 w-full rounded-[12px] py-3 text-white disabled:bg-gray-300'
+          disabled={!nickname || !!nicknameError}
+        >
+          간편 회원가입
+        </button>
+      </form>
+    </main>
+  );
+};
+
+export default KakaoSignupPage;

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -7,6 +7,7 @@ import Input from '@/components/common/Input';
 import ConfirmModal from '@/components/common/ConfirmModal';
 import axios from 'axios';
 import { signupApi } from '@/lib/api/auth';
+import { redirectToKakaoOAuth } from '@/lib/utils/kakao';
 
 const SignupPage = () => {
   const [email, setEmail] = useState('');
@@ -83,8 +84,12 @@ const SignupPage = () => {
     }
   };
 
+  const handleKakaoSignup = () => {
+    redirectToKakaoOAuth();
+  };
+
   return (
-    <main className='min-h-screen flex justify-center px-1 pt-60 lg:pt-100'>
+    <main className='flex min-h-screen justify-center px-1 pt-60 lg:pt-100'>
       {/* 가입 완료 모달 */}
       <ConfirmModal
         isOpen={isSuccessModalOpen}
@@ -103,7 +108,7 @@ const SignupPage = () => {
 
       <form
         onSubmit={handleSubmit}
-        className='w-full max-w-376 md:max-w-640 space-y-24 p-24 md:p-32 bg-white rounded-16'
+        className='rounded-16 w-full max-w-376 space-y-24 bg-white p-24 md:max-w-640 md:p-32'
       >
         {/* 로고 */}
         <div>
@@ -162,34 +167,37 @@ const SignupPage = () => {
         <button
           type='submit'
           disabled={!isFormValid}
-          className='w-full h-48 py-3 rounded-[12px] text-white text-16-m bg-primary-500 disabled:bg-gray-300 cursor-pointer hover:shadow-md hover:shadow-brand-blue/60 transition-all duration-200'
+          className='text-16-m bg-primary-500 hover:shadow-brand-blue/60 h-48 w-full cursor-pointer rounded-[12px] py-3 text-white transition-all duration-200 hover:shadow-md disabled:bg-gray-300'
         >
           회원가입 하기
         </button>
 
         {/* or */}
-        <div className='flex items-center justify-center w-full '>
+        <div className='flex w-full items-center justify-center'>
           <hr className='flex-grow border-t border-gray-300' />
-          <span className='px-16 text-16-m text-gray-500 whitespace-nowrap'>
+          <span className='text-16-m px-16 whitespace-nowrap text-gray-500'>
             sns 계정으로 회원가입하기
           </span>
           <hr className='flex-grow border-t border-gray-300' />
         </div>
 
-        {/* 카카오 로그인 */}
-        <button className='w-full py-12 border border-gray-300 rounded-[12px] flex justify-center items-center text-gray-600 text-16-m cursor-pointer hover:bg-gray-100 transition-colors duration-200'>
+        {/* 카카오 회원가입 */}
+        <button
+          onClick={handleKakaoSignup}
+          className='text-16-m flex w-full cursor-pointer items-center justify-center rounded-[12px] border border-gray-300 py-12 text-gray-600 transition-colors duration-200 hover:bg-gray-100'
+        >
           <img
             src='/icons/icon_kakao.svg'
             alt='kakaoicon'
-            className='text-gray-600 text-13-m w-20 h-20 mr-8'
+            className='text-13-m mr-8 h-20 w-20 text-gray-600'
           />
           카카오 회원가입
         </button>
 
         {/* 로그인 링크 */}
-        <p className='text-center text-13-m text-gray-600'>
+        <p className='text-13-m text-center text-gray-600'>
           회원이신가요?{' '}
-          <Link href='/login' className='text-gray-600 text-13-b underline'>
+          <Link href='/login' className='text-13-b text-gray-600 underline'>
             로그인하기
           </Link>
         </p>

--- a/src/lib/utils/kakao.ts
+++ b/src/lib/utils/kakao.ts
@@ -1,0 +1,7 @@
+export const redirectToKakaoOAuth = () => {
+  const REST_API_KEY = process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY!;
+  const REDIRECT_URI = process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI!;
+  const kakaoAuthUrl = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
+
+  window.location.href = kakaoAuthUrl;
+};


### PR DESCRIPTION
 이슈 번호

- 이슈 번호 #84

## ✨ 요약

<!-- 구현 및 수정한 내용을 간단하게 적어주세요. -->
- 카카오 소셜 로그인 및 신규 회원가입 연동 완료
- 로그인 성공 시 토큰/유저 정보 Zustand에 저장
- 기존 회원은 홈으로 이동, 신규 회원은 닉네임 입력 후 가입 처리
- 닉네임 입력해서 회원가입 요청보내도록 처리
- 인증 관련 에러 처리 및 예외 대응 완료

## 📌 주요 변경 사항

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요. -->
📌 작업 내용
- 카카오 로그인 기능 구현
  - 카카오 로그인 버튼 클릭 시 ``https://kauth.kakao.com/oauth/authorize`` 경로로 리디렉션
  - 로그인 성공 시 code를 포함한 리디렉션 URI로 이동 (``/oauth/kakao``)
- /oauth/kakao 콜백 페이지 처리
  - 받은 code로 POST ``/oauth/sign-in/kakao`` 요청
  - 유저정보가 존재할 경우 토큰 저장 및 홈으로 이동 (``/``) 
  - 유저가 존재하지 않으면 403 또는 404 → 회원가입 페이지(``/oauth/kakao/signup?code=...``)로 이동

- 카카오 간편 회원가입 기능 구현
   - ``/oauth/kakao/signup`` 페이지에서 닉네임 입력 후 POST ``/oauth/sign-up/kakao`` 요청
   - 회원가입 성공 시 토큰 저장 및 홈으로 이동


## 📷 UI 변경 사항 (선택)

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

> 간편로그인/가입 버튼 누르면 이동 ₍ᐢ ̥ ̮ ̥ᐢ₎ *

   <img width="300" alt="image" src="https://github.com/user-attachments/assets/08a838e3-dc6f-471e-9fab-d7df744b73c4" /> 


> 닉네임 입력 후 가입 요청하고 홈으로 이동 ٩(^ᴗ^)۶

  <img width="300" src="https://github.com/user-attachments/assets/c5b5bb9f-2a89-4315-a12e-1bfb91873813" alt="카카오 로그인 로딩 화면" />

> 이미 가입된 계정으로 로그인 후 로딩중٩(^ᴗ^)۶

  <img src="https://github.com/user-attachments/assets/c99d4520-8aeb-4d18-9ff9-8260397279b4" width="300" alt="카카오 로그인 로딩 화면" />



## ❓무슨 문제가 발생했나요 ?

## 💬 논의 사항

<!-- 논의하고 싶은 사항을 적어 주시고, 토론이 필요하시면 토론 탭에 추가 부탁드립니다. -->

## 💬 기타 참고 사항

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->
- .env에 카카오 간편 로그인 구현을 위한 환경변수 추가 ``NEXT_PUBLIC_KAKAO_REDIRECT_URI``
- 배포시에는 uri 추가하고 수정 필요한 부분도 있습니다








