### PR TITLE
🐛Fix: 헤더 스타일 변경으로 인해 sticky가 제대로 동작하지 않던 문제 수정

### DIFF
--- a/src/components/activities/ClientActivitiesPage.tsx
+++ b/src/components/activities/ClientActivitiesPage.tsx
@@ -91,7 +91,7 @@ const ClientActivitiesPage = ({ id }: ClientActivitiesPageProps) => {
         <section
           className={clsx(
             'flex flex-col gap-24',
-            isDesktop ? 'sticky top-20 w-[25.625rem]' : 'mt-20',
+            isDesktop ? 'sticky top-[6.25rem] z-10 w-[25.625rem] self-start' : 'mt-20',
           )}
         >
           <ReservationContent activity={activity} />

--- a/src/components/activities/ClientActivitiesPage.tsx
+++ b/src/components/activities/ClientActivitiesPage.tsx
@@ -91,7 +91,7 @@ const ClientActivitiesPage = ({ id }: ClientActivitiesPageProps) => {
         <section
           className={clsx(
             'flex flex-col gap-24',
-            isDesktop ? 'sticky top-[6.25rem] z-10 w-[25.625rem] self-start' : 'mt-20',
+            isDesktop ? 'sticky top-[6.25rem] w-[25.625rem] self-start' : 'mt-20',
           )}
         >
           <ReservationContent activity={activity} />


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- 없음

## ✨ 요약

<!-- 구현 및 수정한 내용을 간단하게 적어주세요. -->
- 헤더 스타일 변경으로 인해 기존 sicky 동작이 이상해진 문제를 수정하였습니다.

## 📌 주요 변경 사항

- `top-20 -> top-[6.25rem] //100px` 로 변경
- `self-start` 추가

## ❓무슨 문제가 발생했나요 ?

**문제 상황**
- 헤더 높이를 고려하여 `top` 값을 조정했음에도 불구하고, `sticky`가 의도한 위치에 고정되지 않는 현상이 있었습니다. `top` 값을 아무리 높여도 스타일이 제대로 반영되지 않았습니다.



**원인 분석** 
1. 헤더는 `fixed`로 설정되어 있으며, 문서의 공간을 차지 하지 않으며 ` layout.tsx`에 작성되어 있기 때문에 영향이 가지 않습니다.
3. `sticky`는 자신이 속한 부모 요소를 기준으로 고정되므로, 내부 레이아웃 구조에 문제가 있다고 판단했습니다.

**문제 발생 이유**

```tsx
// 수정 전
        {/* 예약 영역 */}
        <section
          className={clsx(
            'flex flex-col gap-24',
            isDesktop ? 'sticky top-20 w-[25.625rem]' : 'mt-20',
          )}
        >
          <ReservationContent activity={activity} />
        </section>
      </div>
````
 원인 : 원인은 `flex` 레이아웃에 있었습니다.
- 기본적으로 `flex`를 사용하면 자식 요소의 `align-self` 값은 기본적으로 `stretch`로 적용되며, 이로 인해 해당 요소의 높이는 부모 요소에 의존하게 됩니다. 이 상태에서는 `sticky`가 정확한 기준 위치를 계산하기 어려워 `sticky`가 작동은 하더라도 개발자가 의도한 위치에서 고정되지 않는 문제가 발생했습니다.

해결 : 결국에는 `self-start`를 통해 자식 요소가 자신의 콘텐츠 만큼에 높이를 갖도록 설정하여 sticky가 정확한 기준 위치를 계산할 수 있도록 변경하여 해당 문제를 해결할 수 있게 되었습니다.

- 보통 헤더에서만 `sticky`를 적용하다 보니까 이런 이슈가 발생할 수도 있었네요 저도 작성하면서 이해하기는 어려운 거 같지만 우선 작성해두었습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 데스크톱 화면에서 예약 섹션의 위치와 정렬이 개선되어, 상단 오프셋이 rem 단위로 조정되고 정렬 스타일이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->