### PR TITLE
✨Feat: 404 페이지 구현

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -7,7 +7,7 @@ const Page = () => {
   const router = useRouter();
   return (
     <>
-      <div className='flex h-screen flex-col items-center justify-center gap-24'>
+      <div className='flex h-[90vh] flex-col items-center justify-center gap-24'>
         <div className='relative size-300'>
           <Image alt='에러 이미지' src={'/icons/404_kkot.svg'} fill />
         </div>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+
+const Page = () => {
+  const router = useRouter();
+  return (
+    <>
+      <div className='flex h-screen flex-col items-center justify-center gap-24'>
+        <div className='relative size-300'>
+          <Image alt='에러 이미지' src={'/icons/404_kkots.svg'} fill />
+        </div>
+        <h1 className='text-14-b md:text-18-b text-center text-gray-500'>
+          앗, 이 페이지는 사라졌거나 존재하지 않아요. <br />
+          다른 페이지를 탐험해보세요!
+        </h1>
+        <button
+          className='bg-primary-500 text-14-m h-50 w-250 self-center rounded-2xl text-white md:w-300'
+          onClick={() => router.push('/')} // 추후 체험 목록 페이지에 맞춰 변경 예정
+        >
+          홈으로 돌아가기
+        </button>
+      </div>
+    </>
+  );
+};
+
+export default Page;

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -9,7 +9,7 @@ const Page = () => {
     <>
       <div className='flex h-screen flex-col items-center justify-center gap-24'>
         <div className='relative size-300'>
-          <Image alt='에러 이미지' src={'/icons/404_kkots.svg'} fill />
+          <Image alt='에러 이미지' src={'/icons/404_kkot.svg'} fill />
         </div>
         <h1 className='text-14-b md:text-18-b text-center text-gray-500'>
           앗, 이 페이지는 사라졌거나 존재하지 않아요. <br />

--- a/src/components/activities/ClientActivitiesPage.tsx
+++ b/src/components/activities/ClientActivitiesPage.tsx
@@ -15,7 +15,7 @@ import ActivityReviewSection from '@/components/activities/sections/ActivityRevi
 import ReservationContent from '@/components/activities/ReservationFlow/ReservationContent';
 
 import type { ActivityDetail } from '@/components/activities/Activities.types';
-import Image from 'next/image';
+import { notFound } from 'next/navigation';
 
 interface ClientActivitiesPageProps {
   id: number;
@@ -49,24 +49,7 @@ const ClientActivitiesPage = ({ id }: ClientActivitiesPageProps) => {
   }, [id]);
 
   if (loading) return <p>로딩 중...</p>;
-  if (!activity)
-    return (
-      <div className='flex min-h-[80vh] flex-col items-center justify-center gap-24'>
-        <div className='relative size-300'>
-          <Image alt='에러 이미지' src={'/icons/404_kkot.svg'} fill />
-        </div>
-        <h1 className='text-14-b md:text-18-b text-center text-gray-500'>
-          데이터를 불러오지 못했습니다. <br />
-          잠시 후 다시 시도해주세요.
-        </h1>
-        <button
-          className='bg-primary-500 text-14-m h-50 w-250 self-center rounded-2xl text-white md:w-300'
-          onClick={() => window.location.reload()}
-        >
-          다시 시도
-        </button>
-      </div>
-    );
+  if (!activity) return notFound();
 
   const isOwner = user?.id === activity.userId;
 


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #145 

## ✨ 요약

<!-- 구현 및 수정한 내용을 간단하게 적어주세요. -->
- 404 페이지를 구현 했습니다.

## 📌 주요 변경 사항

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요. -->
- 기존 클라이언트 페이지에서 사용하고 있던 디자인을 그대로 사용 했습니다.
- 버튼 클릭 시 메인 페이지로 가게 해두었습니다 (경로 변경 시 반영 예정)
- 디자인은 추가 하고 싶거나 피드백 해주시면 반영하겠습니다 (간단하게만 구현한 상황입니다,)

## 📷 UI 변경 사항 (선택)

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->
### PC
<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/51ae46da-5f53-48e1-92a5-647ac52fb9cc" />

### 모바일
<img width="540" height="1025" alt="image" src="https://github.com/user-attachments/assets/c47b8edb-30be-4910-bf0d-ebd32cdf3708" />


## ❓무슨 문제가 발생했나요 ?
- 기존 레이아웃에 `padding`이 들어가 있어서 현재 필요 없는 스크롤이 생기고 있었는데 viewprot를 90으로 사용해서 해결 해놓은 상황입니다. 추후 QA 때 정중앙에 배치되어 있는지 확인하고 수정이 더 필요 할 수 있습니다.

## 💬 논의 사항
- 404도 시멘틱을 챙겨야 할까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 맞춤형 404 에러 페이지가 추가되어, 존재하지 않거나 삭제된 페이지 접근 시 안내 메시지와 홈으로 이동 버튼이 제공됩니다.

* **버그 수정**
  * 활동이 존재하지 않을 때 커스텀 에러 UI 대신 기본 404 페이지가 표시되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->