### PR TITLE
✨Feat: 랜딩페이지 섹션1 구현

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,5 +1,11 @@
+import Section1 from '@/components/landing/Section1';
+
 const LandingPage = () => {
-  return <></>;
+  return (
+    <>
+      <Section1 />
+    </>
+  );
 };
 
 export default LandingPage;

--- a/src/components/landing/Section1.tsx
+++ b/src/components/landing/Section1.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+
+const Section1 = () => {
+  const router = useRouter();
+
+  const handleClick = () => {
+    router.push('/home');
+  };
+
+  return (
+    <div className='bg-primary-100 p10 flex w-full justify-center p-20 sm:p-50 lg:p-100'>
+      <section className='relative mx-auto h-320 w-full max-w-[1448px] overflow-hidden rounded-3xl sm:h-420 lg:h-520'>
+        {/* 배경 이미지 */}
+        <Image
+          src='/imgs/banner.jpg'
+          alt='메인 배너 이미지'
+          fill
+          sizes='(max-width: 768px) 100vw, 50vw'
+          className='object-cover'
+          priority
+        />
+
+        {/* 배경 위 콘텐츠 */}
+        <div className='absolute inset-0 flex flex-col items-center justify-end gap-10 px-14 pb-10 text-center backdrop-blur-sm sm:gap-20 sm:pb-20 lg:gap-24'>
+          {/* 로고 이미지 */}
+          <Image
+            src='/icons/wazylogowhite.svg'
+            alt='wazy logo white'
+            width={0}
+            height={0}
+            sizes='100vw'
+            className='h-100 w-auto sm:h-173 lg:h-212'
+          />
+
+          {/* 소개 문구 */}
+          <p className='text-16-m sm:text-24-m text-white'>
+            체험을 등록하고 <br className='sm:hidden' />
+            즐길 수 있는 가장 쉬운 방법
+          </p>
+
+          {/* 입장하기 버튼 */}
+          <button
+            onClick={handleClick}
+            className='text-14-m hover w-190 rounded-2xl border border-white px-24 py-10 text-white sm:px-32 sm:py-12'
+          >
+            입장하기
+          </button>
+
+          {/* 꽃 라인 */}
+          <div className='mt-18 flex w-full items-center justify-center gap-12 px-4'>
+            <div className='h-2 w-full bg-white' />
+            <Image
+              src='/icons/flower.svg'
+              alt='꽃 아이콘'
+              width={20}
+              height={20}
+              className='h-20 w-20'
+            />
+            <div className='h-2 w-full bg-white' />
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default Section1;

--- a/src/components/landing/Section1.tsx
+++ b/src/components/landing/Section1.tsx
@@ -11,7 +11,7 @@ const Section1 = () => {
   };
 
   return (
-    <div className='bg-primary-100 p10 flex w-full justify-center p-20 sm:p-50 lg:p-100'>
+    <div className='bg-primary-100 flex w-full justify-center p-20 sm:p-50 lg:p-100'>
       <section className='relative mx-auto h-320 w-full max-w-[1448px] overflow-hidden rounded-3xl sm:h-420 lg:h-520'>
         {/* 배경 이미지 */}
         <Image


### PR DESCRIPTION

## 🧩 관련 이슈 번호

- 이슈 번호 #157

## ✨ 요약

<!-- 구현 및 수정한 내용을 간단하게 적어주세요. -->
랜딩페이지 섹션1 구현!!

## 📌 주요 변경 사항

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요. -->

## 📷 UI 변경 사항 (선택)

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->
<img width="2286" height="800" alt="image" src="https://github.com/user-attachments/assets/1fe108d8-0059-4de0-b050-97c13337e113" />
<img width="770" height="600" alt="image" src="https://github.com/user-attachments/assets/7b99a27f-ea57-486b-9c33-9c3fc033b675" />
<img width="374" height="408" alt="image" src="https://github.com/user-attachments/assets/7e02b154-1ad9-4da2-88ef-f619ed1220b1" />


## ❓무슨 문제가 발생했나요 ?

## 💬 논의 사항

<!-- 논의하고 싶은 사항을 적어 주시고, 토론이 필요하시면 토론 탭에 추가 부탁드립니다. -->

## 💬 기타 참고 사항

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 랜딩 페이지에 새로운 섹션(Section1)이 추가되어, 배경 이미지와 로고, 소개 문구, "입장하기" 버튼, 장식용 플라워 라인이 표시됩니다.
  * "입장하기" 버튼 클릭 시 홈(/home) 페이지로 이동합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->